### PR TITLE
CRC checking is wrong

### DIFF
--- a/firmware/Sketches/BasicChat/BasicChat/RadioFunctions.h
+++ b/firmware/Sketches/BasicChat/BasicChat/RadioFunctions.h
@@ -218,7 +218,7 @@ ISR(TRX24_RX_END_vect)
   uint8_t tempFrame[RF_BUFFER_SIZE];
 
   // The received signal must be above a certain threshold.
-  if (rssiRaw & RX_CRC_VALID)
+  if (PHY_RSSI & (1<<RX_CRC_VALID))
   {
     // The length of the message will be the first byte received.
     length = TST_RX_LENGTH;


### PR DESCRIPTION
-RX_CRC_VALID describes a bit position, not a mask
-Checking RX_CRC_VALID needs to happen at the end interrupt, not the start
