### PR TITLE
Add missing parentheses

### DIFF
--- a/firmware/Arduino/hardware/sparkfun/avr/variants/rf128/pins_arduino.h
+++ b/firmware/Arduino/hardware/sparkfun/avr/variants/rf128/pins_arduino.h
@@ -79,7 +79,7 @@ const static uint8_t A7 = 33;
                                 ( ((p) == 12) ? 3 : \
                                 ( ((p) == 13) ? 1 : \
                                 ( ((p) == 20) ? 2 : \
-                                0 ) ) ) ) ) )
+				  0 ) ) ) ) ) )))
 
 #ifdef ARDUINO_MAIN
 


### PR DESCRIPTION
Parentheses in `digitalPinToPCMSKbit` are not balanced, causing build errors for various libraries.  I ran into it with SoftwareSerial.

